### PR TITLE
Reduce number of line pragmas for haddock comments

### DIFF
--- a/library/Require.hs
+++ b/library/Require.hs
@@ -80,7 +80,8 @@ transform' shouldPrepend filename prepended input =
   &   filter (\t -> not $ "autorequire" `Text.isPrefixOf` t)
   &   zip [1..]
   >>= prependAfterModuleLine
-  <&> (\(ln, text) -> maybe (lineTag filename (LineNumber ln) <> text <> "\n") (renderImport filename (LineNumber ln)) $ Megaparsec.parseMaybe requireParser text )
+  <&> (\(ln, text) -> maybe (text <> "\n") (renderImport filename (LineNumber ln)) $ Megaparsec.parseMaybe requireParser text)
+  &   (lineTag filename (LineNumber 1) :)
   &   Text.concat
  where
   enumeratedPrepend ln
@@ -114,7 +115,7 @@ renderImport :: FileName -> LineNumber -> RequireInfo -> Text
 renderImport filename linenumber RequireInfo {..} =
   case (Text.isInfixOf riFullModuleName (unFileName filename)) of
     True  -> ""
-    False -> lineTag filename linenumber <> typesImport <> lineTag filename linenumber <> qualifiedImport
+    False -> typesImport <> lineTag filename linenumber <> qualifiedImport
  where
   types = maybe (Text.takeWhileEnd (/= '.') riFullModuleName) (Text.intercalate ",") riImportedTypes
   typesImport = "import " <> riFullModuleName <> " (" <> types <> ")\n"


### PR DESCRIPTION
With this change only the required line pragmas are generated. Instead of

    <original line>
    {-# LINE ... #-}
    <original line>
    {-# LINE ... #-}
    <original line>

the pragmas are only introduced around the lines generated from the `require` directives:

    module Foo where
    require Bar

is turned into

    module Foo where
    import Bar (Bar)
    {-# LINE ... #-}
    import qualified ...

The main reason for this change is that the previous behaviour didn't play well with haddock comments.

    -- | First line
    -- Second line

would get turned into

    -- | First line
    {-# LINE ... #-}
    -- Second line

which lead to the second line not being included in the haddock output.