### PR TITLE
Allow empty parentheses

### DIFF
--- a/library/Require.hs
+++ b/library/Require.hs
@@ -138,7 +138,7 @@ requireParser = do
 
   types'  <- Megaparsec.option Nothing $ do
     void $ Megaparsec.char '('
-    t' <- Megaparsec.some (Megaparsec.alphaNumChar <|> Megaparsec.char ',' <|> Megaparsec.char ' ')
+    t' <- Megaparsec.many (Megaparsec.alphaNumChar <|> Megaparsec.char ',' <|> Megaparsec.char ' ')
     void $ Megaparsec.char ')'
     return $ Just t'
 

--- a/test-suite/Main.hs
+++ b/test-suite/Main.hs
@@ -70,3 +70,12 @@ spec = parallel $ do
     let expected = "import Data.Text (Text)"
     let actual   = Require.transform False (Require.FileName "Foo.hs") "" input
     expected `Text.isInfixOf` actual
+
+  it "allows empty parentheses" $ do
+    let input       = "require Data.Text ()"
+    let expected1   = "import Data.Text ()"
+    let expected2   = "import qualified Data.Text as Text"
+    let actual      = lines $ Require.transform False (Require.FileName "Foo.hs") "" input
+    actual `shouldSatisfy` elem expected1
+    actual `shouldSatisfy` elem expected2
+


### PR DESCRIPTION
With this small change

```
require Module ()
```

means exactly the same as

```
require Module ( )
```

This fixes #9.