### PR TITLE
Rework the transformation pass

### DIFF
--- a/library/Require.hs
+++ b/library/Require.hs
@@ -148,7 +148,14 @@ transform autorequireEnabled input prepended =
             | otherwise =
                 useTagPrep $ line <> "\n"
 
-      let hasWhere = False -- TODO!
+      let hasWhere =
+            -- TODO: This assumes that comments have whitespace before them and
+            -- that `where` has whitespace before it. But
+            --    module Foo (abc)where--something else
+            -- is valid in Haskell.
+            Text.words line
+              & takeWhile (not . ("--" `Text.isPrefixOf`))
+              & elem "where"
 
       case Megaparsec.parseMaybe requireDirectiveParser line of
         Nothing -> do

--- a/library/Require.hs
+++ b/library/Require.hs
@@ -166,7 +166,6 @@ transform autorequireEnabled input prepended =
         Just AutorequireDirective ->
           processAutorequireContent
 
-    processAutorequireContent :: State TransformState Text
     processAutorequireContent = do
       alreadyAutorequired <- tstAutorequired <<.= True
       autorequireContent  <-
@@ -182,7 +181,7 @@ transform autorequireEnabled input prepended =
       pure autorequireContent
 
 
-renderImport :: State TransformState (Maybe ModuleName) -> LineTag -> RequireInfo -> State TransformState Text
+renderImport :: MonadState TransformState m => m (Maybe ModuleName) -> LineTag -> RequireInfo -> m Text
 renderImport getHostModule line RequireInfo {..} = do
     mhostModule <- getHostModule
     lineTagPrep <- use tstLineTagPrepend

--- a/library/Require.hs
+++ b/library/Require.hs
@@ -118,16 +118,7 @@ run autorequire requiresFile inputFile outputFile = do
   writeFileText (toFilePath outputFile) transformed
 
 transform :: Bool -> FileInput -> Maybe FileInput -> Text
-transform autorequireEnabled input requireInput =
-  transform' input $ do
-    guard $ autorequireEnabled || autorequireDirective
-    requireInput
- where
-   autorequireDirective =
-     any (\t -> "autorequire" `Text.isPrefixOf` t) $ Text.lines $ fiContent input
-
-transform' :: FileInput -> Maybe FileInput -> Text
-transform' input prepended =
+transform autorequireEnabled input prepended =
   fileInputLines input
     & mapM (process (pure Nothing)) -- TODO: If the mapM overhead gets to much maybe use a streaming library.
     & flip evalState initialState

--- a/library/Require.hs
+++ b/library/Require.hs
@@ -121,10 +121,14 @@ run autorequire requiresFile inputFile outputFile = do
 
 transform :: Bool -> FileInput -> Maybe FileInput -> Text
 transform autorequireEnabled input prepended =
+  -- TODO:
+  --  * if the mapM overhead is too much maybe use a streaming library
+  --  * there is no need to concatenate the whole output in memory, a lazy text would be fine
+  --  * maybe we should check if tstAutorequired is set after processing
   fileInputLines input
-    & mapM (process (pure Nothing)) -- TODO: If the mapM overhead gets to much maybe use a streaming library.
+    & mapM (process (pure Nothing))
     & flip evalState initialState
-    & Text.concat       -- TODO: No need to concatenate the whole file in memory, we can create a lazy text here.
+    & Text.concat
   where
     initialState = TransformState
       { _tstLineTagPrepend = prependLineTag
@@ -164,7 +168,6 @@ transform autorequireEnabled input prepended =
 
         Just (ModuleDirective moduleName) -> do
           -- If there is already a module name, don't overwrite it.
-          -- TODO: Can we emit a warning in that case?
           tstHostModule %= (<|> Just moduleName)
           lineWithAutorequire hasWhere
 

--- a/library/Require.hs
+++ b/library/Require.hs
@@ -78,8 +78,8 @@ transform autorequireEnabled filename imports input
 transform' :: Bool -> FileName -> Text -> Text -> Text
 transform' shouldPrepend filename prepended input =
   Text.lines input
-    & filter (\t -> not $ "autorequire" `Text.isPrefixOf` t)
     & zip [1 ..]
+    & filter (\(_, t) -> not $ "autorequire" `Text.isPrefixOf` t)
     >>= prependAfterModuleLine
     <&> (\(ln, text) -> maybe (text <> "\n") (renderImport filename (LineNumber ln)) $ Megaparsec.parseMaybe requireParser text)
     & (lineTag filename (LineNumber 1) :)

--- a/package.yaml
+++ b/package.yaml
@@ -35,7 +35,6 @@ dependencies:
   - megaparsec >= 7 && < 8
   - directory
   - inliterate
-  - microlens-platform
   - optparse-generic
 
 library:

--- a/package.yaml
+++ b/package.yaml
@@ -35,6 +35,7 @@ dependencies:
   - megaparsec >= 7 && < 8
   - directory
   - inliterate
+  - microlens-platform
   - optparse-generic
 
 library:

--- a/require.cabal
+++ b/require.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: f6bc9c2371f0a167829d05ea4cb94a51e5d3ca3e2bc863a82685611213b5cb05
+-- hash: 44a5e193fad05b317af4273b8f9526cd940ca95b5f39734956677cc30b8ed3e8
 
 name:           require
 version:        0.4.6
@@ -46,6 +46,7 @@ library
     , directory
     , inliterate
     , megaparsec >=7 && <8
+    , microlens-platform
     , optparse-generic
     , relude
     , text >=1.2.3.0 && <2
@@ -65,6 +66,7 @@ executable autorequirepp
     , directory
     , inliterate
     , megaparsec >=7 && <8
+    , microlens-platform
     , optparse-generic
     , relude
     , require
@@ -85,6 +87,7 @@ executable requirepp
     , directory
     , inliterate
     , megaparsec >=7 && <8
+    , microlens-platform
     , optparse-generic
     , relude
     , require
@@ -106,6 +109,7 @@ test-suite require-test-suite
     , directory
     , inliterate
     , megaparsec >=7 && <8
+    , microlens-platform
     , optparse-generic
     , relude
     , require
@@ -130,6 +134,7 @@ benchmark require-benchmarks
     , directory
     , inliterate
     , megaparsec >=7 && <8
+    , microlens-platform
     , optparse-generic
     , relude
     , require

--- a/require.cabal
+++ b/require.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 44a5e193fad05b317af4273b8f9526cd940ca95b5f39734956677cc30b8ed3e8
+-- hash: f6bc9c2371f0a167829d05ea4cb94a51e5d3ca3e2bc863a82685611213b5cb05
 
 name:           require
 version:        0.4.6
@@ -46,7 +46,6 @@ library
     , directory
     , inliterate
     , megaparsec >=7 && <8
-    , microlens-platform
     , optparse-generic
     , relude
     , text >=1.2.3.0 && <2
@@ -66,7 +65,6 @@ executable autorequirepp
     , directory
     , inliterate
     , megaparsec >=7 && <8
-    , microlens-platform
     , optparse-generic
     , relude
     , require
@@ -87,7 +85,6 @@ executable requirepp
     , directory
     , inliterate
     , megaparsec >=7 && <8
-    , microlens-platform
     , optparse-generic
     , relude
     , require
@@ -109,7 +106,6 @@ test-suite require-test-suite
     , directory
     , inliterate
     , megaparsec >=7 && <8
-    , microlens-platform
     , optparse-generic
     , relude
     , require
@@ -134,7 +130,6 @@ benchmark require-benchmarks
     , directory
     , inliterate
     , megaparsec >=7 && <8
-    , microlens-platform
     , optparse-generic
     , relude
     , require

--- a/test-suite/Main.hs
+++ b/test-suite/Main.hs
@@ -94,3 +94,18 @@ spec = parallel $ do
           (Require.FileInput (Require.FileName "src/Foo/Bar.hs") fileInput)
           (Just $ Require.FileInput (Require.FileName "Requires") requireInput)
     toString actual `shouldNotContain` notExpected
+  it "surrounds the contents of the Requires file with LINE pragmas" $ do
+    let fileInput = Text.unlines [ "module Main where", "import B" ]
+    let requireInput = Text.unlines [ "import A" ]
+    let expected = Text.unlines
+          [ "{-# LINE \"Foo.hs\" 1 #-}"
+          , "module Main where"
+          , "{-# LINE \"Requires\" 1 #-}"
+          , "import A"
+          , "{-# LINE \"Foo.hs\" 2 #-}"
+          , "import B"
+          ]
+    let actual = Require.transform True
+          (Require.FileInput (Require.FileName "Foo.hs") fileInput)
+          (Just $ Require.FileInput (Require.FileName "Requires") requireInput)
+    actual `shouldBe` expected

--- a/test-suite/Main.hs
+++ b/test-suite/Main.hs
@@ -14,89 +14,137 @@ spec = parallel $ do
   let emptyRequiresFile =
         Just $ Require.FileInput (Require.FileName "Requires") ""
 
-  it "transforms the 'require' keyword into a properly qualified import" $ do
-    let input = "require Data.Text"
-    let expected = "import qualified Data.Text as Text"
-    let actual = Require.transform False
-          (Require.FileInput (Require.FileName "Foo.hs") input)
-          emptyRequiresFile
-    expected `Text.isInfixOf` actual
-  it "imports the type based on the module" $ do
-    let input = "require Data.Text"
-    let expected = "import Data.Text (Text)"
-    let actual = Require.transform False
-          (Require.FileInput (Require.FileName "Foo.hs") input)
-          emptyRequiresFile
-    expected `Text.isInfixOf` actual
-  it "keeps the rest of the content intact" $ do
-    let input = "module Foo where\nrequire Data.Text\nfoo = 42"
-    let expectedStart = "{-# LINE 1"
-    let expectedModule = "module Foo where"
-    let expectedTypeImport = "import Data.Text (Text)"
-    let expectedQualifiedImport = "import qualified Data.Text as Text"
-    let expectedContent = "foo = 42\n"
-    let actual = toString $ Require.transform False
-          (Require.FileInput (Require.FileName "Foo.hs") input)
-          emptyRequiresFile
-    actual `shouldStartWith` expectedStart
-    actual `shouldContain` expectedModule
-    actual `shouldContain` expectedTypeImport
-    actual `shouldContain` expectedQualifiedImport
-    actual `shouldEndWith` expectedContent
-  it "aliases the modules properly" $ do
-    let input = "require Data.Text as Foo"
-    let expectedTypeImport = "import Data.Text (Text)"
-    let expectedQualifiedImport = "import qualified Data.Text as Foo"
-    let actual = toString $ Require.transform False
-          (Require.FileInput (Require.FileName "Foo.hs") input)
-          emptyRequiresFile
-    actual `shouldContain` expectedTypeImport
-    actual `shouldContain` expectedQualifiedImport
-  it "imports the types properly" $ do
-    let input = "require Data.Text (Foo)"
-    let expectedTypeImport = "import Data.Text (Foo)"
-    let expectedQualifiedImport = "import qualified Data.Text as Text"
-    let actual = toString $ Require.transform False
-          (Require.FileInput (Require.FileName "Foo.hs") input)
-          emptyRequiresFile
-    actual `shouldContain` expectedTypeImport
-    actual `shouldContain` expectedQualifiedImport
-  it "imports the types and aliases the modules properly" $ do
-    let input = "require Data.Text as Quux (Foo)"
-    let expectedTypeImport = "import Data.Text (Foo)"
-    let expectedQualifiedImport = "import qualified Data.Text as Quux"
-    let actual = toString $ Require.transform False
-          (Require.FileInput (Require.FileName "Foo.hs") input)
-          emptyRequiresFile
-    actual `shouldContain` expectedTypeImport
-    actual `shouldContain` expectedQualifiedImport
-  it "skips comments" $ do
-    let input = "require Data.Text -- test of comments"
-    let expected = "import Data.Text (Text)"
-    let actual = Require.transform False
-          (Require.FileInput (Require.FileName "Foo.hs") input)
-          emptyRequiresFile
-    expected `Text.isInfixOf` actual
-  it "allows empty parentheses" $ do
-    let input = "require Data.Text ()"
-    let expected1 = "import Data.Text ()"
-    let expected2 = "import qualified Data.Text as Text"
-    let actual = lines $ Require.transform False
-          (Require.FileInput (Require.FileName "Foo.hs") input)
-          emptyRequiresFile
-    actual `shouldSatisfy` elem expected1
-    actual `shouldSatisfy` elem expected2
+  describe "the transformation" $ do
+    it "transforms the 'require' keyword into a properly qualified import" $ do
+      let input = "require Data.Text"
+      let expected = "import qualified Data.Text as Text"
+      let actual = Require.transform False
+            (Require.FileInput (Require.FileName "Foo.hs") input)
+            emptyRequiresFile
+      expected `Text.isInfixOf` actual
+    it "imports the type based on the module" $ do
+      let input = "require Data.Text"
+      let expected = "import Data.Text (Text)"
+      let actual = Require.transform False
+            (Require.FileInput (Require.FileName "Foo.hs") input)
+            emptyRequiresFile
+      expected `Text.isInfixOf` actual
+    it "keeps the rest of the content intact" $ do
+      let input = "module Foo where\nrequire Data.Text\nfoo = 42"
+      let expectedStart = "{-# LINE 1"
+      let expectedModule = "module Foo where"
+      let expectedTypeImport = "import Data.Text (Text)"
+      let expectedQualifiedImport = "import qualified Data.Text as Text"
+      let expectedContent = "foo = 42\n"
+      let actual = toString $ Require.transform False
+            (Require.FileInput (Require.FileName "Foo.hs") input)
+            emptyRequiresFile
+      actual `shouldStartWith` expectedStart
+      actual `shouldContain` expectedModule
+      actual `shouldContain` expectedTypeImport
+      actual `shouldContain` expectedQualifiedImport
+      actual `shouldEndWith` expectedContent
+    it "aliases the modules properly" $ do
+      let input = "require Data.Text as Foo"
+      let expectedTypeImport = "import Data.Text (Text)"
+      let expectedQualifiedImport = "import qualified Data.Text as Foo"
+      let actual = toString $ Require.transform False
+            (Require.FileInput (Require.FileName "Foo.hs") input)
+            emptyRequiresFile
+      actual `shouldContain` expectedTypeImport
+      actual `shouldContain` expectedQualifiedImport
+    it "imports the types properly" $ do
+      let input = "require Data.Text (Foo)"
+      let expectedTypeImport = "import Data.Text (Foo)"
+      let expectedQualifiedImport = "import qualified Data.Text as Text"
+      let actual = toString $ Require.transform False
+            (Require.FileInput (Require.FileName "Foo.hs") input)
+            emptyRequiresFile
+      actual `shouldContain` expectedTypeImport
+      actual `shouldContain` expectedQualifiedImport
+    it "imports the types and aliases the modules properly" $ do
+      let input = "require Data.Text as Quux (Foo)"
+      let expectedTypeImport = "import Data.Text (Foo)"
+      let expectedQualifiedImport = "import qualified Data.Text as Quux"
+      let actual = toString $ Require.transform False
+            (Require.FileInput (Require.FileName "Foo.hs") input)
+            emptyRequiresFile
+      actual `shouldContain` expectedTypeImport
+      actual `shouldContain` expectedQualifiedImport
+    it "skips comments" $ do
+      let input = "require Data.Text -- test of comments"
+      let expected = "import Data.Text (Text)"
+      let actual = Require.transform False
+            (Require.FileInput (Require.FileName "Foo.hs") input)
+            emptyRequiresFile
+      expected `Text.isInfixOf` actual
+    it "allows empty parentheses" $ do
+      let input = "require Data.Text ()"
+      let expected1 = "import Data.Text ()"
+      let expected2 = "import qualified Data.Text as Text"
+      let actual = lines $ Require.transform False
+            (Require.FileInput (Require.FileName "Foo.hs") input)
+            emptyRequiresFile
+      actual `shouldSatisfy` elem expected1
+      actual `shouldSatisfy` elem expected2
+
+  describe "require-mode" $ do
+    it "respects autorequire directives" $ do
+      let fileInput = Text.unlines [ "module Main where", "autorequire", "import B" ]
+      let requireInput = Text.unlines [ "import A" ]
+      let actual = Text.lines $ Require.transform False
+            (Require.FileInput (Require.FileName "src/Foo/Bar.hs") fileInput)
+            (Just $ Require.FileInput (Require.FileName "Requires") requireInput)
+      actual `shouldSatisfy` elem "module Main where"
+      actual `shouldSatisfy` elem "import A"
+      actual `shouldSatisfy` elem "import B"
 
   describe "autorequire-mode" $ do
+    describe "inclusion after module directive" $ do
+      let checkInclusion n fileInput = do
+            let requireInput = "import A"
+            let actual = Text.lines $ Require.transform True
+                  (Require.FileInput (Require.FileName "src/Foo/Bar.hs") fileInput)
+                  (Just $ Require.FileInput (Require.FileName "Requires") requireInput)
+            let elemN x = (n ==) . length . filter (x ==)
+            actual `shouldSatisfy` elemN requireInput
+
+      it "works for no export list" $ do
+        checkInclusion 1 "module Main where"
+      it "works for a one line export list" $ do
+        checkInclusion 1 "module Main (Datatype(..), (*+), foo, Bar) where"
+      it "works for a multi line export list" $ do
+        checkInclusion 1 $ Text.unlines
+          [ "module Main"
+          , "  ( -- * Foo"
+          , "  , Foo(..)"
+          , "  , (*+)"
+          , "  , -- ** Bar"
+          , "  foo, Bar"
+          , "  ) where"
+          ]
+      it "doesn't add after data/class/instance declarations" $ do
+        checkInclusion 0 $ Text.unlines
+          [ "class Foo a where"
+          , "instance Foo x => Bar (Baz x) where"
+          , "data Vec n a where"
+          , "  Nil :: Vec 0 a"
+          , "  Cons :: a -> Vec n a -> Vec (n + 1) a"
+          ]
+      it "doesn't add after data/class/instance declarations split to multiple lines" $ do
+        checkInclusion 0 $ Text.unlines
+          [ "class Foo a -- some explanation here"
+          , "  where"
+          ]
+
     it "drops self-imports" $ do
       let fileInput = "module Foo.Bar where"
       let requireInput = "require Foo.Bar"
       let notExpected = "import Foo.Bar"
       let actual = Require.transform True
             (Require.FileInput (Require.FileName "src/Foo/Bar.hs") fileInput)
-            (Require.FileInput (Require.FileName "Requires") requireInput)
+            (Just $ Require.FileInput (Require.FileName "Requires") requireInput)
       toString actual `shouldNotContain` notExpected
-
     it "adds LINE pragmas around the Requires contents" $ do
       let fileInput = Text.unlines [ "module Main where", "import B" ]
       let requireInput = Text.unlines [ "import A" ]
@@ -110,5 +158,5 @@ spec = parallel $ do
             ]
       let actual = Require.transform True
             (Require.FileInput (Require.FileName "Foo.hs") fileInput)
-            (Require.FileInput (Require.FileName "Requires") requireInput)
+            (Just $ Require.FileInput (Require.FileName "Requires") requireInput)
       actual `shouldBe` expected

--- a/test-suite/Main.hs
+++ b/test-suite/Main.hs
@@ -98,6 +98,16 @@ spec = parallel $ do
       actual `shouldSatisfy` elem "module Main where"
       actual `shouldSatisfy` elem "import A"
       actual `shouldSatisfy` elem "import B"
+    it "keeps requires where the module is a substring of the filename" $ do
+      -- Test case for https://github.com/theam/require/issues/20
+      let fileInput = Text.unlines [ "module FooTest where", "require Foo" ]
+      let expected1 = "import Foo (Foo)"
+      let expected2 = "import qualified Foo as Foo"
+      let actual = lines $ Require.transform False
+            (Require.FileInput (Require.FileName "FooTests.hs") fileInput)
+            emptyRequiresFile
+      actual `shouldSatisfy` elem expected1
+      actual `shouldSatisfy` elem expected2
 
   describe "autorequire-mode" $ do
     describe "inclusion after module directive" $ do

--- a/test-suite/Main.hs
+++ b/test-suite/Main.hs
@@ -67,3 +67,10 @@ spec = parallel $ do
     let actual = lines $ Require.transform False (Require.FileName "Foo.hs") "" input
     actual `shouldSatisfy` elem expected1
     actual `shouldSatisfy` elem expected2
+
+  it "autorequire does not lead to self-imports" $ do
+    let fileInput     = "module Foo.Bar where"
+    let requireInput  = "require Foo.Bar"
+    let notExpected   = "import Foo.Bar"
+    let actual        = Require.transform True (Require.FileName "src/Foo/Bar.hs") requireInput fileInput
+    toString actual `shouldNotContain` notExpected

--- a/test-suite/Main.hs
+++ b/test-suite/Main.hs
@@ -14,12 +14,16 @@ spec = parallel $ do
   it "transforms the 'require' keyword into a properly qualified import" $ do
     let input = "require Data.Text"
     let expected = "import qualified Data.Text as Text"
-    let actual = Require.transform False (Require.FileName "Foo.hs") "" input
+    let actual = Require.transform False
+          (Require.FileInput (Require.FileName "Foo.hs") input)
+          ""
     expected `Text.isInfixOf` actual
   it "imports the type based on the module" $ do
     let input = "require Data.Text"
     let expected = "import Data.Text (Text)"
-    let actual = Require.transform False (Require.FileName "Foo.hs") "" input
+    let actual = Require.transform False
+          (Require.FileInput (Require.FileName "Foo.hs") input)
+          ""
     expected `Text.isInfixOf` actual
   it "keeps the rest of the content intact" $ do
     let input = "module Foo where\nrequire Data.Text\nfoo = 42"
@@ -28,7 +32,9 @@ spec = parallel $ do
     let expectedTypeImport = "import Data.Text (Text)"
     let expectedQualifiedImport = "import qualified Data.Text as Text"
     let expectedContent = "foo = 42\n"
-    let actual = toString $ Require.transform False (Require.FileName "Foo.hs") "" input
+    let actual = toString $ Require.transform False
+          (Require.FileInput (Require.FileName "Foo.hs") input)
+          ""
     actual `shouldStartWith` expectedStart
     actual `shouldContain` expectedModule
     actual `shouldContain` expectedTypeImport
@@ -38,39 +44,50 @@ spec = parallel $ do
     let input = "require Data.Text as Foo"
     let expectedTypeImport = "import Data.Text (Text)"
     let expectedQualifiedImport = "import qualified Data.Text as Foo"
-    let actual = toString $ Require.transform False (Require.FileName "Foo.hs") "" input
+    let actual = toString $ Require.transform False
+          (Require.FileInput (Require.FileName "Foo.hs") input)
+          ""
     actual `shouldContain` expectedTypeImport
     actual `shouldContain` expectedQualifiedImport
   it "imports the types properly" $ do
     let input = "require Data.Text (Foo)"
     let expectedTypeImport = "import Data.Text (Foo)"
     let expectedQualifiedImport = "import qualified Data.Text as Text"
-    let actual = toString $ Require.transform False (Require.FileName "Foo.hs") "" input
+    let actual = toString $ Require.transform False
+          (Require.FileInput (Require.FileName "Foo.hs") input)
+          ""
     actual `shouldContain` expectedTypeImport
     actual `shouldContain` expectedQualifiedImport
   it "imports the types and aliases the modules properly" $ do
     let input = "require Data.Text as Quux (Foo)"
     let expectedTypeImport = "import Data.Text (Foo)"
     let expectedQualifiedImport = "import qualified Data.Text as Quux"
-    let actual = toString $ Require.transform False (Require.FileName "Foo.hs") "" input
+    let actual = toString $ Require.transform False
+          (Require.FileInput (Require.FileName "Foo.hs") input)
+          ""
     actual `shouldContain` expectedTypeImport
     actual `shouldContain` expectedQualifiedImport
   it "skips comments" $ do
     let input = "require Data.Text -- test of comments"
     let expected = "import Data.Text (Text)"
-    let actual = Require.transform False (Require.FileName "Foo.hs") "" input
+    let actual = Require.transform False
+          (Require.FileInput (Require.FileName "Foo.hs") input)
+          ""
     expected `Text.isInfixOf` actual
   it "allows empty parentheses" $ do
     let input = "require Data.Text ()"
     let expected1 = "import Data.Text ()"
     let expected2 = "import qualified Data.Text as Text"
-    let actual = lines $ Require.transform False (Require.FileName "Foo.hs") "" input
+    let actual = lines $ Require.transform False
+          (Require.FileInput (Require.FileName "Foo.hs") input)
+          ""
     actual `shouldSatisfy` elem expected1
     actual `shouldSatisfy` elem expected2
-
   it "autorequire does not lead to self-imports" $ do
-    let fileInput     = "module Foo.Bar where"
-    let requireInput  = "require Foo.Bar"
-    let notExpected   = "import Foo.Bar"
-    let actual        = Require.transform True (Require.FileName "src/Foo/Bar.hs") requireInput fileInput
+    let fileInput = "module Foo.Bar where"
+    let requireInput = "require Foo.Bar"
+    let notExpected = "import Foo.Bar"
+    let actual = Require.transform True
+          (Require.FileInput (Require.FileName "src/Foo/Bar.hs") fileInput)
+          requireInput
     toString actual `shouldNotContain` notExpected


### PR DESCRIPTION
This is a (quite large) rework of how input files are transformed. The main points are

* Keep a state throughout, to keep things from happening twice
* Extract the module name from the `module … where` directive and use this module name to drop require-directives from the Requires file
* There aren't actually that many changes in the test suite, but I added indentation to structure the different cases in `describe` blocks.

A side effect of these changes is that #20 is fixed. I'll use #21 to add a test case for this.
