### PR TITLE
Support Require files in require mode again

### DIFF
--- a/library/Require.hs
+++ b/library/Require.hs
@@ -25,7 +25,8 @@ findRequires = do
 requireMain :: IO ()
 requireMain = do
   CommandArguments inputFile _ outputFile <- getRecord "Require Haskell preprocessor" :: IO CommandArguments
-  run (AutorequireOnDirective Nothing) (File.Name inputFile) (File.Name outputFile)
+  requiresFile <- findRequires
+  run (AutorequireOnDirective requiresFile) (File.Name inputFile) (File.Name outputFile)
 
 autorequireMain :: IO ()
 autorequireMain = do


### PR DESCRIPTION
### The story of *autorequire* and *Requires* files

1. Discussed in #6 
2. First implementation in #8, from now on a Requires file *had* to be present, even in normal *require* mode.
3. This problem was fixed by #24, but completely eliminating the ability to use the `autorequire` directive in *require* mode because now no Requires file got loaded

### What this PR wants to solve

As I understand it, we want to allow a Requires file in *require* mode, but this file should be *optional.*

---

* [x] This depends on #26.