### PR TITLE
Adjust dependecies to be buildable with LTS 15

### DIFF
--- a/library/Require/File.hs
+++ b/library/Require/File.hs
@@ -30,7 +30,7 @@ data LineTag = LineTag !Name !LineNumber
 -- | Returns the 'LineTag' referencing the first line in a given 'FileInput'.
 --
 -- Note that the tag's line number is 1-based, which fits well with how GHC
--- understands @{-# LINE ... #-}@ pragmas.
+-- understands @{-\# LINE ... #-}@ pragmas.
 initialLineTag :: Input -> LineTag
 initialLineTag inp = LineTag (inputName inp) (LineNumber 1)
 

--- a/package.yaml
+++ b/package.yaml
@@ -32,7 +32,7 @@ dependencies:
   - relude
   - bytestring >= 0.10 && < 0.11
   - text >= 1.2.3.0 && < 2
-  - megaparsec >= 7 && < 8
+  - megaparsec >= 7 && < 9
   - directory
   - optparse-generic
 

--- a/package.yaml
+++ b/package.yaml
@@ -34,7 +34,6 @@ dependencies:
   - text >= 1.2.3.0 && < 2
   - megaparsec >= 7 && < 8
   - directory
-  - inliterate
   - optparse-generic
 
 library:

--- a/require.cabal
+++ b/require.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: ceeb2f9c5a160393a1fd86ca01c63c4d957d256ae92501abfd87e3d415f5c686
+-- hash: 2239329d0c9b3828b5abc3dc46e2264a9243a39dd360b47bf1f6f1bd1b9e9c19
 
 name:           require
 version:        0.4.8
@@ -48,7 +48,6 @@ library
       base >=4.9 && <5
     , bytestring >=0.10 && <0.11
     , directory
-    , inliterate
     , megaparsec >=7 && <8
     , optparse-generic
     , relude
@@ -67,7 +66,6 @@ executable autorequirepp
       base >=4.9 && <5
     , bytestring >=0.10 && <0.11
     , directory
-    , inliterate
     , megaparsec >=7 && <8
     , optparse-generic
     , relude
@@ -87,7 +85,6 @@ executable requirepp
       base >=4.9 && <5
     , bytestring >=0.10 && <0.11
     , directory
-    , inliterate
     , megaparsec >=7 && <8
     , optparse-generic
     , relude
@@ -108,7 +105,6 @@ test-suite require-test-suite
       base >=4.9 && <5
     , bytestring >=0.10 && <0.11
     , directory
-    , inliterate
     , megaparsec >=7 && <8
     , optparse-generic
     , relude
@@ -132,7 +128,6 @@ benchmark require-benchmarks
     , bytestring >=0.10 && <0.11
     , criterion
     , directory
-    , inliterate
     , megaparsec >=7 && <8
     , optparse-generic
     , relude

--- a/require.cabal
+++ b/require.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 2239329d0c9b3828b5abc3dc46e2264a9243a39dd360b47bf1f6f1bd1b9e9c19
+-- hash: b5fbb89313fc25a016996a3226294577eb819df7a681a9f5f08459446898196f
 
 name:           require
 version:        0.4.8
@@ -48,7 +48,7 @@ library
       base >=4.9 && <5
     , bytestring >=0.10 && <0.11
     , directory
-    , megaparsec >=7 && <8
+    , megaparsec >=7 && <9
     , optparse-generic
     , relude
     , text >=1.2.3.0 && <2
@@ -66,7 +66,7 @@ executable autorequirepp
       base >=4.9 && <5
     , bytestring >=0.10 && <0.11
     , directory
-    , megaparsec >=7 && <8
+    , megaparsec >=7 && <9
     , optparse-generic
     , relude
     , require
@@ -85,7 +85,7 @@ executable requirepp
       base >=4.9 && <5
     , bytestring >=0.10 && <0.11
     , directory
-    , megaparsec >=7 && <8
+    , megaparsec >=7 && <9
     , optparse-generic
     , relude
     , require
@@ -105,7 +105,7 @@ test-suite require-test-suite
       base >=4.9 && <5
     , bytestring >=0.10 && <0.11
     , directory
-    , megaparsec >=7 && <8
+    , megaparsec >=7 && <9
     , optparse-generic
     , relude
     , require
@@ -128,7 +128,7 @@ benchmark require-benchmarks
     , bytestring >=0.10 && <0.11
     , criterion
     , directory
-    , megaparsec >=7 && <8
+    , megaparsec >=7 && <9
     , optparse-generic
     , relude
     , require


### PR DESCRIPTION
This includes

* Dropping the (unused) `inliterate` dependency
* Relaxing the `megaparsec` constraint

Code changes were not necessary.

---

I hope I am not causing to much trouble with this constant stream of pull requests! I have one more small thing nearly done improving error messages and runtime performance.