### PR TITLE
Improve error reporting and runtime performance

### DIFF
--- a/library/Require.hs
+++ b/library/Require.hs
@@ -43,4 +43,4 @@ run autoMode inputFile outputFile = do
   autoInput <- traverse File.read autoMode
   case transform autoInput input of
     Left err -> die (Error.describe err)
-    Right tr -> File.write outputFile tr
+    Right ls -> File.writeLines outputFile ls

--- a/library/Require.hs
+++ b/library/Require.hs
@@ -34,7 +34,7 @@ autorequireMain = do
   CommandArguments inputFile _ outputFile <- getRecord "Require Haskell preprocessor" :: IO CommandArguments
   requiresFile <- findRequires
   case requiresFile of
-    Nothing -> die "There is no Requires file in the system"
+    Nothing -> Error.die (File.Name inputFile) Error.MissingRequiresFile
     Just fn -> run (AutorequireEnabled fn) (File.Name inputFile) (File.Name outputFile)
 
 run :: AutorequireMode File.Name -> File.Name -> File.Name -> IO ()

--- a/library/Require.hs
+++ b/library/Require.hs
@@ -40,5 +40,6 @@ run :: AutorequireMode File.Name -> File.Name -> File.Name -> IO ()
 run autoMode inputFile outputFile = do
   input <- File.read inputFile
   autoInput <- traverse File.read autoMode
-  let transformed = transform autoInput input
-  File.write outputFile transformed
+  case transform autoInput input of
+    Left err -> die err
+    Right tr -> File.write outputFile tr

--- a/library/Require.hs
+++ b/library/Require.hs
@@ -42,5 +42,5 @@ run autoMode inputFile outputFile = do
   input <- File.read inputFile
   autoInput <- traverse File.read autoMode
   case transform autoInput input of
-    Left err -> die (Error.describe err)
+    Left err -> Error.die inputFile err
     Right ls -> File.writeLines outputFile ls

--- a/library/Require.hs
+++ b/library/Require.hs
@@ -4,6 +4,7 @@ import qualified Data.Text as Text
 import Options.Generic
 import Relude
 import System.Directory
+import qualified Require.Error as Error
 import qualified Require.File as File
 import Require.Transform
 import Require.Types
@@ -41,5 +42,5 @@ run autoMode inputFile outputFile = do
   input <- File.read inputFile
   autoInput <- traverse File.read autoMode
   case transform autoInput input of
-    Left err -> die err
+    Left err -> die (Error.describe err)
     Right tr -> File.write outputFile tr

--- a/library/Require/Error.hs
+++ b/library/Require/Error.hs
@@ -9,14 +9,16 @@ import System.IO
 
 data Error
   = MissingRequiresFile
+  | MissingOptionalRequiresFile
   | AutorequireImpossible
   deriving (Eq, Show)
 
 
 describe :: Error -> [String]
 describe MissingRequiresFile =
-  [ "Discovered an `autorequire` directive but no `Requires` file was found."
-  ]
+  [ "`autorequirepp` couldn't find a `Requires` file in the system." ]
+describe MissingOptionalRequiresFile =
+  [ "Discovered an `autorequire` directive but no `Requires` file was found." ]
 describe AutorequireImpossible =
   [ "Unable to determine where to insert the autorequire contents."
   , "Use the `autorequire` directive to specify a location yourself."

--- a/library/Require/Error.hs
+++ b/library/Require/Error.hs
@@ -1,6 +1,10 @@
 module Require.Error where
 
+import Control.Exception
 import Relude
+import qualified Require.File as File
+import System.Console.ANSI
+import System.IO
 
 
 data Error
@@ -9,9 +13,27 @@ data Error
   deriving (Eq, Show)
 
 
-describe :: Error -> String
+describe :: Error -> [String]
 describe MissingRequiresFile =
-  "discovered an `autorequire` directive but no `Requires` file was found."
+  [ "Discovered an `autorequire` directive but no `Requires` file was found."
+  ]
 describe AutorequireImpossible =
-  "unable to determine where to insert the autorequire contents.\n\
-  \  Use the `autorequire` directive to specify a location yourself."
+  [ "Unable to determine where to insert the autorequire contents."
+  , "Use the `autorequire` directive to specify a location yourself."
+  ]
+
+
+die :: File.Name -> Error -> IO a
+die (File.Name fn) e = do
+  let outputHeaderColored = do
+        hSetSGR stderr [SetConsoleIntensity BoldIntensity]
+        hPutStr stderr (toString fn ++ ": ")
+        hSetSGR stderr [SetColor Foreground Vivid Red]
+        hPutStr stderr "error:\n"
+
+  -- Don't mess up the terminal if there is an exception half-way through.
+  outputHeaderColored `finally` hSetSGR stderr []
+
+  let indent s = replicate 4 ' ' ++ s
+  traverse_ (hPutStrLn stderr . indent) (describe e)
+  exitFailure

--- a/library/Require/Error.hs
+++ b/library/Require/Error.hs
@@ -5,8 +5,13 @@ import Relude
 
 data Error
   = MissingRequiresFile
+  | AutorequireImpossible
   deriving (Eq, Show)
 
 
 describe :: Error -> String
-describe MissingRequiresFile = "Found an `autorequire` directive but no `Requires` file was found."
+describe MissingRequiresFile =
+  "discovered an `autorequire` directive but no `Requires` file was found."
+describe AutorequireImpossible =
+  "unable to determine where to insert the autorequire contents.\n\
+  \  Use the `autorequire` directive to specify a location yourself."

--- a/library/Require/Error.hs
+++ b/library/Require/Error.hs
@@ -1,0 +1,12 @@
+module Require.Error where
+
+import Relude
+
+
+data Error
+  = MissingRequiresFile
+  deriving (Eq, Show)
+
+
+describe :: Error -> String
+describe MissingRequiresFile = "Found an `autorequire` directive but no `Requires` file was found."

--- a/library/Require/File.hs
+++ b/library/Require/File.hs
@@ -9,6 +9,7 @@
 module Require.File where
 
 import Relude
+import qualified Data.Text.IO as TIO
 
 -- | Wraps the name of a file as given by the user. Usually this corresponds to
 -- the file's path.
@@ -42,9 +43,11 @@ advanceLineTag (LineTag fn ln) = LineTag fn (succ ln)
 read :: Name -> IO Input
 read f = Input f <$> readFileText (nameToPath f)
 
--- | @write name content@ writes @content@ to the file identified by @name@.
-write :: Name -> Text -> IO ()
-write = writeFileText . nameToPath
+-- | @write name lines@ writes all every line in @lines@ to the file identified
+-- by @name@ and appends a newline.
+writeLines :: Name -> [Text] -> IO ()
+writeLines name theLines = withFile (nameToPath name) WriteMode $ \h ->
+  traverse_ (TIO.hPutStrLn h) theLines
 
 -- | Splits the input into lines and annotates each with a 'LineTag'.
 inputLines :: Input -> [(LineTag, Text)]

--- a/library/Require/Transform.hs
+++ b/library/Require/Transform.hs
@@ -2,6 +2,7 @@
 module Require.Transform where
 
 import Control.Category ((>>>))
+import Control.Monad.Except
 import qualified Data.Text as Text
 import Relude
 import qualified Require.File as File
@@ -73,8 +74,7 @@ process filterImports (tag, line) = do
                 processAutorequireContent autoContent
           AutorequireOnDirective Nothing
             | isDirective ->
-                -- TODO: Better error reporting.
-                error "Found an `autorequire` directive but no `Requires` file was found."
+                throwError "Found an `autorequire` directive but no `Requires` file was found."
           _ | isDirective -> pure ""
             | otherwise   -> useTagPrep $ line <> "\n"
 

--- a/library/Require/Transform.hs
+++ b/library/Require/Transform.hs
@@ -101,7 +101,7 @@ process filterImports (tag, line) = do
             | isDirective -> processAutorequireContent autoContent
 
           AutorequireOnDirective Nothing
-            | isDirective -> throwError MissingRequiresFile
+            | isDirective -> throwError MissingOptionalRequiresFile
 
           _ | isDirective -> pure ()
             | otherwise   -> useTagPrep >> output line

--- a/package.yaml
+++ b/package.yaml
@@ -36,6 +36,7 @@ dependencies:
   - mtl >= 2.2.1
   - directory
   - optparse-generic
+  - dlist
 
 library:
   source-dirs: library

--- a/package.yaml
+++ b/package.yaml
@@ -37,6 +37,7 @@ dependencies:
   - directory
   - optparse-generic
   - dlist
+  - ansi-terminal
 
 library:
   source-dirs: library

--- a/package.yaml
+++ b/package.yaml
@@ -33,6 +33,7 @@ dependencies:
   - bytestring >= 0.10 && < 0.11
   - text >= 1.2.3.0 && < 2
   - megaparsec >= 7 && < 9
+  - mtl >= 2.2.1
   - directory
   - optparse-generic
 

--- a/package.yaml
+++ b/package.yaml
@@ -49,8 +49,6 @@ executables:
       - require
     ghc-options:
       - -rtsopts
-      - -threaded
-      - -with-rtsopts=-N
   autorequirepp:
     source-dirs: executable/AutoRequire/
     main: Main.hs
@@ -58,8 +56,6 @@ executables:
       - require
     ghc-options:
       - -rtsopts
-      - -threaded
-      - -with-rtsopts=-N
 
 benchmarks:
   require-benchmarks:

--- a/require.cabal
+++ b/require.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: b5fbb89313fc25a016996a3226294577eb819df7a681a9f5f08459446898196f
+-- hash: cc313f3532ad0cb7e84807d8057036999f2bc476e96ececc26a5afbc9375191a
 
 name:           require
 version:        0.4.8
@@ -49,6 +49,7 @@ library
     , bytestring >=0.10 && <0.11
     , directory
     , megaparsec >=7 && <9
+    , mtl >=2.2.1
     , optparse-generic
     , relude
     , text >=1.2.3.0 && <2
@@ -67,6 +68,7 @@ executable autorequirepp
     , bytestring >=0.10 && <0.11
     , directory
     , megaparsec >=7 && <9
+    , mtl >=2.2.1
     , optparse-generic
     , relude
     , require
@@ -86,6 +88,7 @@ executable requirepp
     , bytestring >=0.10 && <0.11
     , directory
     , megaparsec >=7 && <9
+    , mtl >=2.2.1
     , optparse-generic
     , relude
     , require
@@ -106,6 +109,7 @@ test-suite require-test-suite
     , bytestring >=0.10 && <0.11
     , directory
     , megaparsec >=7 && <9
+    , mtl >=2.2.1
     , optparse-generic
     , relude
     , require
@@ -129,6 +133,7 @@ benchmark require-benchmarks
     , criterion
     , directory
     , megaparsec >=7 && <9
+    , mtl >=2.2.1
     , optparse-generic
     , relude
     , require

--- a/require.cabal
+++ b/require.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 25f008ba92d8664cb116c449c78a787c5d204822c10d96ab6712fa046b3c7e40
+-- hash: 2616af9282392d5469785d8f1f099aa3856d6d7b6d83a1e098a51f9892129e8e
 
 name:           require
 version:        0.4.8
@@ -49,6 +49,7 @@ library
       base >=4.9 && <5
     , bytestring >=0.10 && <0.11
     , directory
+    , dlist
     , megaparsec >=7 && <9
     , mtl >=2.2.1
     , optparse-generic
@@ -68,6 +69,7 @@ executable autorequirepp
       base >=4.9 && <5
     , bytestring >=0.10 && <0.11
     , directory
+    , dlist
     , megaparsec >=7 && <9
     , mtl >=2.2.1
     , optparse-generic
@@ -88,6 +90,7 @@ executable requirepp
       base >=4.9 && <5
     , bytestring >=0.10 && <0.11
     , directory
+    , dlist
     , megaparsec >=7 && <9
     , mtl >=2.2.1
     , optparse-generic
@@ -109,6 +112,7 @@ test-suite require-test-suite
       base >=4.9 && <5
     , bytestring >=0.10 && <0.11
     , directory
+    , dlist
     , megaparsec >=7 && <9
     , mtl >=2.2.1
     , optparse-generic
@@ -133,6 +137,7 @@ benchmark require-benchmarks
     , bytestring >=0.10 && <0.11
     , criterion
     , directory
+    , dlist
     , megaparsec >=7 && <9
     , mtl >=2.2.1
     , optparse-generic

--- a/require.cabal
+++ b/require.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: aad0fd86e3ceb4bec02932edf1b6d1a47bd7f875cad4b061bb16f37e9972b37d
+-- hash: bb70ccb8324225986d8fb8a3a54207684bea945c731d90225ec3d9bde1df2cfe
 
 name:           require
 version:        0.4.8
@@ -46,7 +46,8 @@ library
   default-extensions: NoImplicitPrelude OverloadedStrings TypeApplications RecordWildCards DeriveGeneric
   ghc-options: -Wall
   build-depends:
-      base >=4.9 && <5
+      ansi-terminal
+    , base >=4.9 && <5
     , bytestring >=0.10 && <0.11
     , directory
     , dlist
@@ -66,7 +67,8 @@ executable autorequirepp
   default-extensions: NoImplicitPrelude OverloadedStrings TypeApplications RecordWildCards DeriveGeneric
   ghc-options: -Wall -rtsopts
   build-depends:
-      base >=4.9 && <5
+      ansi-terminal
+    , base >=4.9 && <5
     , bytestring >=0.10 && <0.11
     , directory
     , dlist
@@ -87,7 +89,8 @@ executable requirepp
   default-extensions: NoImplicitPrelude OverloadedStrings TypeApplications RecordWildCards DeriveGeneric
   ghc-options: -Wall -rtsopts
   build-depends:
-      base >=4.9 && <5
+      ansi-terminal
+    , base >=4.9 && <5
     , bytestring >=0.10 && <0.11
     , directory
     , dlist
@@ -109,7 +112,8 @@ test-suite require-test-suite
   default-extensions: NoImplicitPrelude OverloadedStrings TypeApplications RecordWildCards DeriveGeneric
   ghc-options: -Wall -rtsopts -threaded -with-rtsopts=-N
   build-depends:
-      base >=4.9 && <5
+      ansi-terminal
+    , base >=4.9 && <5
     , bytestring >=0.10 && <0.11
     , directory
     , dlist
@@ -133,7 +137,8 @@ benchmark require-benchmarks
   default-extensions: NoImplicitPrelude OverloadedStrings TypeApplications RecordWildCards DeriveGeneric
   ghc-options: -Wall -rtsopts -threaded -with-rtsopts=-N
   build-depends:
-      base >=4.9 && <5
+      ansi-terminal
+    , base >=4.9 && <5
     , bytestring >=0.10 && <0.11
     , criterion
     , directory

--- a/require.cabal
+++ b/require.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: cc313f3532ad0cb7e84807d8057036999f2bc476e96ececc26a5afbc9375191a
+-- hash: 25f008ba92d8664cb116c449c78a787c5d204822c10d96ab6712fa046b3c7e40
 
 name:           require
 version:        0.4.8
@@ -34,6 +34,7 @@ source-repository head
 library
   exposed-modules:
       Require
+      Require.Error
       Require.File
       Require.Parser
       Require.Transform

--- a/require.cabal
+++ b/require.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 2616af9282392d5469785d8f1f099aa3856d6d7b6d83a1e098a51f9892129e8e
+-- hash: aad0fd86e3ceb4bec02932edf1b6d1a47bd7f875cad4b061bb16f37e9972b37d
 
 name:           require
 version:        0.4.8
@@ -64,7 +64,7 @@ executable autorequirepp
   hs-source-dirs:
       executable/AutoRequire/
   default-extensions: NoImplicitPrelude OverloadedStrings TypeApplications RecordWildCards DeriveGeneric
-  ghc-options: -Wall -rtsopts -threaded -with-rtsopts=-N
+  ghc-options: -Wall -rtsopts
   build-depends:
       base >=4.9 && <5
     , bytestring >=0.10 && <0.11
@@ -85,7 +85,7 @@ executable requirepp
   hs-source-dirs:
       executable/Require/
   default-extensions: NoImplicitPrelude OverloadedStrings TypeApplications RecordWildCards DeriveGeneric
-  ghc-options: -Wall -rtsopts -threaded -with-rtsopts=-N
+  ghc-options: -Wall -rtsopts
   build-depends:
       base >=4.9 && <5
     , bytestring >=0.10 && <0.11

--- a/test-suite/Main.hs
+++ b/test-suite/Main.hs
@@ -139,7 +139,7 @@ spec = parallel $ do
         let actual = Require.transform
               (AutorequireOnDirective Nothing)
               (File.Input (File.Name "Foo.hs") fileInput)
-        actual `shouldBe` Left Error.MissingRequiresFile
+        actual `shouldBe` Left Error.MissingOptionalRequiresFile
 
   describe "autorequire-mode" $ do
     describe "inclusion after module directive" $ do

--- a/test-suite/Main.hs
+++ b/test-suite/Main.hs
@@ -165,18 +165,28 @@ spec = parallel $ do
           , "  ) where"
           ]
       it "doesn't add after data/class/instance declarations" $ do
-        checkInclusion 0 $ Text.unlines
-          [ "class Foo a where"
-          , "instance Foo x => Bar (Baz x) where"
-          , "data Vec n a where"
-          , "  Nil :: Vec 0 a"
-          , "  Cons :: a -> Vec n a -> Vec (n + 1) a"
-          ]
+        let fileInput = unlines
+              [ "class Foo a where"
+              , "instance Foo x => Bar (Baz x) where"
+              , "data Vec n a where"
+              , "  Nil :: Vec 0 a"
+              , "  Cons :: a -> Vec n a -> Vec (n + 1) a"
+              ]
+        let requireInput = unlines [ "import A" ]
+        let actual = Require.transform
+              (AutorequireEnabled $ File.Input (File.Name "Requires") requireInput)
+              (File.Input (File.Name "Foo.hs") fileInput)
+        actual `shouldBe` Left Error.AutorequireImpossible
       it "doesn't add after data/class/instance declarations split to multiple lines" $ do
-        checkInclusion 0 $ Text.unlines
-          [ "class Foo a -- some explanation here"
-          , "  where"
-          ]
+        let fileInput = unlines
+              [ "class Foo a -- some explanation here"
+              , "  where"
+              ]
+        let requireInput = unlines [ "import A" ]
+        let actual = Require.transform
+              (AutorequireEnabled $ File.Input (File.Name "Requires") requireInput)
+              (File.Input (File.Name "Foo.hs") fileInput)
+        actual `shouldBe` Left Error.AutorequireImpossible
 
     describe "triggered using the autorequire directive" $ do
       it "can be triggered before without a module directive" $ do

--- a/test-suite/Main.hs
+++ b/test-suite/Main.hs
@@ -13,21 +13,36 @@ main = do
 
 spec :: Spec
 spec = parallel $ do
+  let transform autoMode fileInput =
+        case Require.transform autoMode fileInput of
+          Left err -> do
+            -- sadly expectationFailure is not polymorphic in its return type
+            expectationFailure $ "Tranform failed: " ++ err
+            pure $ error "expectationFailure should have thrown"
+          Right tr ->
+            pure tr
+
+  let transformString autoMode =
+         fmap toString . transform autoMode
+
+  let transformLines autoMode =
+         fmap lines . transform autoMode
+
   describe "the transformation" $ do
     it "transforms the 'require' keyword into a properly qualified import" $ do
       let input = "require Data.Text"
       let expected = "import qualified Data.Text as Text"
-      let actual = Require.transform
+      actual <- transformString
             AutorequireDisabled
             (File.Input (File.Name "Foo.hs") input)
-      expected `Text.isInfixOf` actual
+      actual `shouldContain` expected
     it "imports the type based on the module" $ do
       let input = "require Data.Text"
       let expected = "import Data.Text (Text)"
-      let actual = Require.transform
+      actual <- transformString
             AutorequireDisabled
             (File.Input (File.Name "Foo.hs") input)
-      expected `Text.isInfixOf` actual
+      actual `shouldContain` expected
     it "keeps the rest of the content intact" $ do
       let input = "module Foo where\nrequire Data.Text\nfoo = 42"
       let expectedStart = "{-# LINE 1"
@@ -35,7 +50,7 @@ spec = parallel $ do
       let expectedTypeImport = "import Data.Text (Text)"
       let expectedQualifiedImport = "import qualified Data.Text as Text"
       let expectedContent = "foo = 42\n"
-      let actual = toString $ Require.transform
+      actual <- transformString
             AutorequireDisabled
             (File.Input (File.Name "Foo.hs") input)
       actual `shouldStartWith` expectedStart
@@ -47,7 +62,7 @@ spec = parallel $ do
       let input = "require Data.Text as Foo"
       let expectedTypeImport = "import Data.Text (Text)"
       let expectedQualifiedImport = "import qualified Data.Text as Foo"
-      let actual = toString $ Require.transform
+      actual <- transformString
             AutorequireDisabled
             (File.Input (File.Name "Foo.hs") input)
       actual `shouldContain` expectedTypeImport
@@ -56,7 +71,7 @@ spec = parallel $ do
       let input = "require Data.Text (Foo)"
       let expectedTypeImport = "import Data.Text (Foo)"
       let expectedQualifiedImport = "import qualified Data.Text as Text"
-      let actual = toString $ Require.transform
+      actual <- transformString
             AutorequireDisabled
             (File.Input (File.Name "Foo.hs") input)
       actual `shouldContain` expectedTypeImport
@@ -65,7 +80,7 @@ spec = parallel $ do
       let input = "require Data.Text as Quux (Foo)"
       let expectedTypeImport = "import Data.Text (Foo)"
       let expectedQualifiedImport = "import qualified Data.Text as Quux"
-      let actual = toString $ Require.transform
+      actual <- transformString
             AutorequireDisabled
             (File.Input (File.Name "Foo.hs") input)
       actual `shouldContain` expectedTypeImport
@@ -73,15 +88,15 @@ spec = parallel $ do
     it "skips comments" $ do
       let input = "require Data.Text -- test of comments"
       let expected = "import Data.Text (Text)"
-      let actual = Require.transform
+      actual <- transformString
             AutorequireDisabled
             (File.Input (File.Name "Foo.hs") input)
-      expected `Text.isInfixOf` actual
+      actual `shouldContain` expected
     it "allows empty parentheses" $ do
       let input = "require Data.Text ()"
       let expected1 = "import Data.Text ()"
       let expected2 = "import qualified Data.Text as Text"
-      let actual = lines $ Require.transform
+      actual <- transformLines
             AutorequireDisabled
             (File.Input (File.Name "Foo.hs") input)
       actual `shouldSatisfy` elem expected1
@@ -91,7 +106,7 @@ spec = parallel $ do
     it "respects autorequire directives" $ do
       let fileInput = Text.unlines [ "module Main where", "autorequire", "import B" ]
       let requireInput = Text.unlines [ "import A" ]
-      let actual = Text.lines $ Require.transform
+      actual <- transformLines
             (AutorequireOnDirective $ Just $ File.Input (File.Name "Requires") requireInput)
             (File.Input (File.Name "src/Foo/Bar.hs") fileInput)
       actual `shouldSatisfy` elem "module Main where"
@@ -101,7 +116,7 @@ spec = parallel $ do
     it "ignores a second autorequire directive" $ do
       let fileInput = Text.unlines [ "autorequire", "autorequire" ]
       let requireInput = Text.unlines [ "import A" ]
-      let actual = Text.lines $ Require.transform
+      actual <- transformLines
             (AutorequireOnDirective $ Just $ File.Input (File.Name "Requires") requireInput)
             (File.Input (File.Name "src/Foo/Bar.hs") fileInput)
       actual `shouldSatisfy` elemN 1 "import A"
@@ -111,7 +126,7 @@ spec = parallel $ do
       let fileInput = Text.unlines [ "module FooTest where", "require Foo" ]
       let expected1 = "import Foo (Foo)"
       let expected2 = "import qualified Foo as Foo"
-      let actual = lines $ Require.transform
+      actual <- transformLines
             AutorequireDisabled
             (File.Input (File.Name "FooTests.hs") fileInput)
       actual `shouldSatisfy` elem expected1
@@ -121,7 +136,7 @@ spec = parallel $ do
     describe "inclusion after module directive" $ do
       let checkInclusion n fileInput = do
             let requireInput = "import A"
-            let actual = Text.lines $ Require.transform
+            actual <- transformLines
                   (AutorequireEnabled $ File.Input (File.Name "Requires") requireInput)
                   (File.Input (File.Name "src/Foo/Bar.hs") fileInput)
             actual `shouldSatisfy` elemN n requireInput
@@ -164,7 +179,7 @@ spec = parallel $ do
               , "{-# LINE 2 \"Foo.hs\" #-}"
               , "main = return ()"
               ]
-        let actual = Require.transform
+        actual <- transform
               (AutorequireEnabled $ File.Input (File.Name "Requires") requireInput)
               (File.Input (File.Name "Foo.hs") fileInput)
         actual `shouldBe` expected
@@ -177,7 +192,7 @@ spec = parallel $ do
               , "{-# LINE 1 \"Requires\" #-}"
               , "import A"
               ]
-        let actual = Require.transform
+        actual <- transform
               (AutorequireEnabled $ File.Input (File.Name "Requires") requireInput)
               (File.Input (File.Name "Foo.hs") fileInput)
         actual `shouldBe` expected
@@ -190,7 +205,7 @@ spec = parallel $ do
               , "{-# LINE 2 \"Foo.hs\" #-}"
               , "module Main where"
               ]
-        let actual = Require.transform
+        actual <- transform
               (AutorequireEnabled $ File.Input (File.Name "Requires") requireInput)
               (File.Input (File.Name "Foo.hs") fileInput)
         actual `shouldBe` expected
@@ -199,7 +214,7 @@ spec = parallel $ do
       let fileInput = "module Foo.Bar where"
       let requireInput = "require Foo.Bar"
       let notExpected = "import Foo.Bar"
-      let actual = Require.transform
+      actual <- transform
             (AutorequireEnabled $ File.Input (File.Name "Requires") requireInput)
             (File.Input (File.Name "src/Foo/Bar.hs") fileInput)
       toString actual `shouldNotContain` notExpected
@@ -214,7 +229,7 @@ spec = parallel $ do
             , "{-# LINE 2 \"Foo.hs\" #-}"
             , "import B"
             ]
-      let actual = Require.transform
+      actual <- transform
             (AutorequireEnabled $ File.Input (File.Name "Requires") requireInput)
             (File.Input (File.Name "Foo.hs") fileInput)
       actual `shouldBe` expected

--- a/test-suite/Main.hs
+++ b/test-suite/Main.hs
@@ -14,7 +14,7 @@ main = do
 
 spec :: Spec
 spec = parallel $ do
-  let transform autoMode fileInput =
+  let transformLines autoMode fileInput =
         case Require.transform autoMode fileInput of
           Left err -> do
             -- sadly expectationFailure is not polymorphic in its return type
@@ -23,11 +23,11 @@ spec = parallel $ do
           Right tr ->
             pure tr
 
-  let transformString autoMode =
+      transformString autoMode =
          fmap toString . transform autoMode
 
-  let transformLines autoMode =
-         fmap lines . transform autoMode
+      transform autoMode =
+         fmap unlines . transformLines autoMode
 
   describe "the transformation" $ do
     it "transforms the 'require' keyword into a properly qualified import" $ do


### PR DESCRIPTION
### Error reporting improvements

The idea is to have the error messages stand out more, I remember having to stare at the output for a few moments to find the one line containing the error message.

Compare the current output
```
req-errors> build (lib + exe)
Preprocessing library for req-errors-0.0.0..
Building library for req-errors-0.0.0..
There is no Requires file in the system
`autorequirepp' failed in phase `Haskell pre-processor'. (Exit code: 1)
```
with the new output
```
req-errors> build (lib + exe)
Preprocessing library for req-errors-0.0.0..
Building library for req-errors-0.0.0..
src/Lib.hs: error:
    `autorequirepp` couldn't find a `Requires` file in the system.
`autorequirepp' failed in phase `Haskell pre-processor'. (Exit code: 1)
```

For the same reason I also added coloring (`ansi-terminal` is already a transitive dependency):

<img width="599" alt="Bildschirmfoto 2020-04-15 um 15 23 22" src="https://user-images.githubusercontent.com/2131598/79342153-132a0c00-7f2d-11ea-9663-85f21585c828.png">

### Runtime improvements

1. Don't concatenate the whole output file in memory, instead we output line by line. This decreases memory usage as reported by `+RTS -s`
2. Don't use the threaded runtime as there is no need for it. In my measurements this cuts the runtime more than in half.